### PR TITLE
fix: use github.sha for changed files diff to support squash merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         id: changed
         run: |
           echo "files<<EOF" >> $GITHUB_OUTPUT
-          git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} >> $GITHUB_OUTPUT
+          git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Bump versions and update changelogs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Claude Guidelines
+
+## Git workflow
+
+- **Never push directly to `main`**. Always create a branch, open a PR, and merge it.
+- Use squash merges for PRs.


### PR DESCRIPTION
## Summary

- Fixes the `release` job failing when PRs are squash-merged: `github.event.pull_request.head.sha` points to a commit that no longer exists after squashing, causing `git diff` to error with `fatal: bad object`. Replaced with `github.sha`, which is the actual squash commit on `main`.
- Adds `CLAUDE.md` with a project-level rule: never push directly to `main`, always use a PR.

## Root cause

After a squash merge, the individual branch commits are rewritten into a single commit. The original head SHA (`github.event.pull_request.head.sha`) no longer exists in the repo's history, but `github.sha` always refers to the resulting commit on the base branch.