### PR TITLE
chore: add PR title validation and Claude rules

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,16 @@
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  validate:
+    name: Conventional commit title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,4 +3,5 @@
 ## Git workflow
 
 - **Never push directly to `main`**. Always create a branch, open a PR, and merge it.
-- Use squash merges for PRs.
+- Do not squash merge automatically. Only squash merge if explicitly asked.
+- PR titles must follow the [conventional commit](https://www.conventionalcommits.org/) format (e.g. `feat: add button`, `fix!: breaking change`). This is enforced by CI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,4 @@
 - **Never push directly to `main`**. Always create a branch, open a PR, and merge it.
 - Do not squash merge automatically. Only squash merge if explicitly asked.
 - PR titles must follow the [conventional commit](https://www.conventionalcommits.org/) format (e.g. `feat: add button`, `fix!: breaking change`). This is enforced by CI.
+- Do not commit or push to GitHub without explicit confirmation from the user.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/validate-pr-title.yml` — runs on every PR open, edit, reopen, or sync; fails if the title doesn't follow [conventional commit](https://www.conventionalcommits.org/) format. The `edited` trigger specifically covers title changes, so the check re-runs any time the title is updated.
- Updates `CLAUDE.md` with two new rules: no automatic squash merges, and PR titles must follow conventional commit format.

## Why

The `release.mjs` script determines semver bump type from the PR title (`feat:` → minor, `feat!:` → major, etc.). An invalid title would either be silently treated as a patch or produce unexpected results. This check prevents that at the source.