### PR TITLE
chore: always squash merge PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,6 @@
 ## Git workflow
 
 - **Never push directly to `main`**. Always create a branch, open a PR, and merge it.
-- Do not squash merge automatically. Only squash merge if explicitly asked.
+- Always squash merge PRs.
 - PR titles must follow the [conventional commit](https://www.conventionalcommits.org/) format (e.g. `feat: add button`, `fix!: breaking change`). This is enforced by CI.
 - Do not commit or push to GitHub without explicit confirmation from the user.


### PR DESCRIPTION
Updates the Claude rule from 'only squash merge if explicitly asked' to 'always squash merge'.